### PR TITLE
Add R in insurance 2016 file to _conferences, and R in insurance 2017 in a index page.

### DIFF
--- a/_conferences/Rininsurance2016.md
+++ b/_conferences/Rininsurance2016.md
@@ -1,0 +1,13 @@
+---
+name: R in insurance 
+year: 2016
+location: London, UK
+date: 2016-08-11
+talks:
+  - title: estudy2: an R package for the event study in insurance
+    speaker: Iegor Rudnytskyi
+    topics: finance insurance
+    url: https://irudnyts.github.io/pdf/rinins.pdf
+
+
+---

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@ title: Home
 <h3>Incoming Conferences</h3>
 <ul>
   <li>useR! 2017 <span style="float: right">July 4, 2017</span></li>
+  <li>R in insurance 2017 <span style="float: right">June 8, 2017</span></li>
 </ul>
 
 <h3><a href="archive">Conferences</a></h3>


### PR DESCRIPTION
- Add Rininsurance2016.md file, which contains a link to talk's pdf.
- Add the announcement of R in insurance 2017 conference to index.html